### PR TITLE
Added Content Assist Favorites

### DIFF
--- a/com.vogella.saneclipse.preferences/src/com/vogella/saneclipse/preferences/internal/PreferenceInitializerAddon.java
+++ b/com.vogella.saneclipse.preferences/src/com/vogella/saneclipse/preferences/internal/PreferenceInitializerAddon.java
@@ -41,6 +41,7 @@ public class PreferenceInitializerAddon {
 		// commented out until https://bugs.eclipse.org/bugs/show_bug.cgi?id=453125 is solved
 		// prefs.put("content_assist_autoactivation_triggers_java",
 		//		".abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_");
+		prefs.put("content_assist_favorite_static_members", "org.hamcrest.Matchers.*;org.junit.Assert.*;org.mockito.Mockito.*");
 		prefs.put("org.eclipse.jdt.ui.typefilter.enabled", "java.awt.*;javax.swing.*;");
 		prefs.putBoolean("content_assist_insert_completion", false);
 		prefs.putBoolean("enclosingBrackets", true);


### PR DESCRIPTION
This PR adds the following Content Assist Favorites

org.hamcrest.Matchers.*
org.junit.Assert.*
org.mockito.Mockito.*

There's probably other useful types or members that can be added but it's something to start with.
